### PR TITLE
New Region struct to replace the ad hoc regions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 1.1.0
+
+- Regions are a clearer way to distinguish collections of countries.
+- Even more regions are added, including the X Eyes spy programs.
+- We now show you what regions are available and what they mean.
+
 ## Version 1.0.1
 
 - OpenSSL will be compiled from sources to avoid upstream problems

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -97,6 +97,24 @@ impl Region {
         }
     }
 
+    /// Returns all possible region codes with their respective meanings in human readable form.
+    /// Useful to provide lists to your users to choose from.
+    ///
+    /// Using a value from index 0 of the tuple will guaranteed give a Some when calling `[from_str](#method_from_str)`
+    pub fn from_str_options() -> [(&'static str, &'static str); 8] {
+        [
+            ("EU", "The European Union"),
+            ("ЕЮ", "The European Union"),
+            ("EEA", "The European Economic Area"),
+            ("BENELUX", "Countries of the Benelux"),
+            ("5E", "Countries involved in the Five Eyes programme."),
+            ("6E", "Countries involved in the Six Eyes programme."),
+            ("9E", "Countries involved in the Nine Eyes programme."),
+            ("14E", "Countries involved in the Fourteen Eyes programme."),
+        ]
+    }
+
+    /// Returns the main short notation for a given Region.
     pub fn short(&self) -> &'static str {
         match self {
             Region::EuropeanUnion => "EU",

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -186,6 +186,7 @@ impl CountriesFilter {
         since = "1.1.0",
         note = "Use the Region object instead. It has more regions and better."
     )]
+    #[allow(deprecated)]
     pub fn from_region(region: &str) -> Option<CountriesFilter> {
         match region.to_lowercase().as_ref() {
             "eu" | "ею" => Some(CountriesFilter {
@@ -494,33 +495,33 @@ mod tests {
     #[test]
     fn valid_regions() {
         assert_eq!(
-            Region::from_str("eu").unwrap().countries(),
+            Region::from_str("EU").unwrap().countries(),
             vec![
                 "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR", "HU", "IE",
                 "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE",
             ]
         );
         assert_eq!(
-            Region::from_str("ею").unwrap().countries(),
+            Region::from_str("ЕЮ").unwrap().countries(),
             vec![
                 "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR", "HU", "IE",
                 "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE",
             ]
         );
         assert_eq!(
-            Region::from_str("5e").unwrap().countries(),
+            Region::from_str("5E").unwrap().countries(),
             vec!["AU", "CA", "NZ", "GB", "US"]
         );
         assert_eq!(
-            Region::from_str("6e").unwrap().countries(),
+            Region::from_str("6E").unwrap().countries(),
             vec!["AU", "CA", "FR", "NZ", "GB", "US"]
         );
         assert_eq!(
-            Region::from_str("9e").unwrap().countries(),
+            Region::from_str("9E").unwrap().countries(),
             vec!["AU", "CA", "DK", "FR", "NL", "NO", "NZ", "GB", "US"]
         );
         assert_eq!(
-            Region::from_str("14e").unwrap().countries(),
+            Region::from_str("14E").unwrap().countries(),
             vec![
                 "AU", "BE", "CA", "DE", "DK", "ES", "FR", "IT", "NL", "NO", "NZ", "GB", "SE", "US",
             ],

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -59,6 +59,7 @@ impl<'a> From<&'a str> for CountryFilter {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub enum Region {
     /// The European Union, consisting of 27 countries.
     ///
@@ -85,8 +86,8 @@ impl Region {
             "eea" => Some(Region::EuropeanEconomicArea),
             "benelux" => Some(Region::Benelux),
             "5e" => Some(Region::FiveEyes),
-            "6e" => Some(Region::FiveEyes),
-            "9e" => Some(Region::FiveEyes),
+            "6e" => Some(Region::SixEyes),
+            "9e" => Some(Region::NineEyes),
             "14e" => Some(Region::FourteenEyes),
             _ => None,
         }
@@ -439,5 +440,51 @@ mod tests {
 
         assert!(server_opt.is_some());
         assert_eq!(server_opt.unwrap().flag, "AZ");
+    }
+
+    #[test]
+    fn valid_regions() {
+        assert_eq!(
+            Region::from_str("eu").unwrap().countries(),
+            vec![
+                "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR", "HU", "IE",
+                "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE",
+            ]
+        );
+        assert_eq!(
+            Region::from_str("ею").unwrap().countries(),
+            vec![
+                "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR", "HU", "IE",
+                "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE",
+            ]
+        );
+        assert_eq!(
+            Region::from_str("5e").unwrap().countries(),
+            vec!["AU", "CA", "NZ", "GB", "US"]
+        );
+        assert_eq!(
+            Region::from_str("6e").unwrap().countries(),
+            vec!["AU", "CA", "FR", "NZ", "GB", "US"]
+        );
+        assert_eq!(
+            Region::from_str("9e").unwrap().countries(),
+            vec!["AU", "CA", "DK", "FR", "NL", "NO", "NZ", "GB", "US"]
+        );
+        assert_eq!(
+            Region::from_str("14e").unwrap().countries(),
+            vec![
+                "AU", "BE", "CA", "DE", "DK", "ES", "FR", "IT", "NL", "NO", "NZ", "GB", "SE", "US",
+            ],
+        )
+    }
+
+    #[test]
+    fn invalid_regions() {
+        assert_eq!(Region::from_str("blablabla"), None);
+        assert_eq!(Region::from_str(""), None);
+        assert_eq!(Region::from_str("idk"), None);
+        assert_eq!(Region::from_str("test"), None);
+        assert_eq!(Region::from_str("12e"), None);
+        assert_eq!(Region::from_str("15e"), None);
     }
 }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -34,7 +34,10 @@ pub struct CountryFilter {
 impl CountryFilter {
     /// Creates a CountryFilter from the given country. The countrycode should be an
     /// [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code.
-    #[deprecated(since = "1.0.0", note = "Inefficient, use the From-trait implementation instead")]
+    #[deprecated(
+        since = "1.0.0",
+        note = "Inefficient, use the From-trait implementation instead"
+    )]
     pub fn from_code(countrycode: String) -> CountryFilter {
         CountryFilter {
             country: countrycode.to_ascii_uppercase(),
@@ -52,6 +55,73 @@ impl<'a> From<&'a str> for CountryFilter {
     fn from(countrycode: &str) -> CountryFilter {
         CountryFilter {
             country: countrycode.to_ascii_uppercase(),
+        }
+    }
+}
+
+pub enum Region {
+    /// The European Union, consisting of 27 countries.
+    ///
+    /// Because of the Brexit, the United Kingdom is not included in this region
+    EuropeanUnion,
+    /// The European Economic Area, consisting of the European Union, Norway, Lichtenstein and Iceland.
+    EuropeanEconomicArea,
+    /// The Benelux consists of Belgium, The Netherlands and Luxembourgh
+    Benelux,
+    /// [5 eyes programme countries](https://en.wikipedia.org/wiki/Five_Eyes)
+    FiveEyes,
+    /// [6 eyes programme countries.](https://en.wikipedia.org/wiki/Five_Eyes#Other_international_cooperatives)
+    SixEyes,
+    /// [9 eyes programme countries.](https://en.wikipedia.org/wiki/Five_Eyes#Other_international_cooperatives)
+    NineEyes,
+    /// [14 eyes programme countries.](https://en.wikipedia.org/wiki/Five_Eyes#Other_international_cooperatives)
+    FourteenEyes,
+}
+
+impl Region {
+    pub fn from_str(region_short: &str) -> Option<Region> {
+        match region_short {
+            "eu" | "ею" => Some(Region::EuropeanUnion),
+            "eea" => Some(Region::EuropeanEconomicArea),
+            "benelux" => Some(Region::Benelux),
+            "5e" => Some(Region::FiveEyes),
+            "6e" => Some(Region::FiveEyes),
+            "9e" => Some(Region::FiveEyes),
+            "14e" => Some(Region::FourteenEyes),
+            _ => None,
+        }
+    }
+
+    pub fn short(&self) -> &'static str {
+        match self {
+            Region::EuropeanUnion => "eu",
+            Region::EuropeanEconomicArea => "eea",
+            Region::Benelux => "benelux",
+            Region::FiveEyes => "5e",
+            Region::SixEyes => "6e",
+            Region::NineEyes => "9e",
+            Region::FourteenEyes => "14e",
+        }
+    }
+
+    pub fn countries(&self) -> Vec<&str> {
+        match self {
+            Region::EuropeanEconomicArea => vec![
+                "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR", "HU", "IE",
+                "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE", "NO",
+                "LI", "IS",
+            ],
+            Region::EuropeanUnion => vec![
+                "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR", "HU", "IE",
+                "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE",
+            ],
+            Region::Benelux => vec!["BE", "LU", "NL"],
+            Region::FiveEyes => vec!["AU", "CA", "NZ", "GB", "US"],
+            Region::SixEyes => vec!["AU", "CA", "FR", "NZ", "GB", "US"],
+            Region::NineEyes => vec!["AU", "CA", "DK", "FR", "NL", "NO", "NZ", "GB", "US"],
+            Region::FourteenEyes => vec![
+                "AU", "BE", "CA", "DE", "DK", "ES", "FR", "IT", "NL", "NO", "NZ", "GB", "SE", "US",
+            ],
         }
     }
 }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -525,7 +525,12 @@ mod tests {
             vec![
                 "AU", "BE", "CA", "DE", "DK", "ES", "FR", "IT", "NL", "NO", "NZ", "GB", "SE", "US",
             ],
-        )
+        );
+
+        // Make sure we do not forget a region
+        for (region, _) in Region::from_str_options().into_iter() {
+            assert!(Region::from_str(region).is_some());
+        }
     }
 
     #[test]

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -182,6 +182,10 @@ impl CountriesFilter {
     ///
     /// When calling this with one of the `[available_regions](method.available_regions)` will
     /// always return `Some(CountriesFilter)`.
+    #[deprecated(
+        since = "1.1.0",
+        note = "Use the Region object instead. It has more regions and better."
+    )]
     pub fn from_region(region: &str) -> Option<CountriesFilter> {
         match region.to_lowercase().as_ref() {
             "eu" | "ею" => Some(CountriesFilter {
@@ -200,12 +204,20 @@ impl CountriesFilter {
     ///
     /// When calling [from_region](method.from_region) with one of the values in the returned slice
     /// should always give a `Some`-value.
+    #[deprecated(
+        since = "1.1.0",
+        note = "Use the Region object instead. It has more regions and better."
+    )]
     pub fn available_regions() -> &'static [&'static str] {
         &["EU", "ЕЮ"]
     }
 
     /// Returns the countries that are represented by the given region. Regions should be in
     /// [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format.
+    #[deprecated(
+        since = "1.1.0",
+        note = "Use the Region object instead. It has more regions and better."
+    )]
     pub fn region_countries(region: &str) -> Option<&'static [&'static str]> {
         match region.as_ref() {
             "EU" | "ЕЮ" => Some(&[
@@ -446,6 +458,8 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
+
     fn countries_filter_regions_give_some() {
         for region in CountriesFilter::available_regions() {
             assert!(CountriesFilter::from_region(region).is_some());

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -80,28 +80,32 @@ pub enum Region {
 }
 
 impl Region {
+    /// Tries to create a Region from a string slice. Returns a Region if there's one represented
+    /// by your str slice. Returns None otherwise.
+    ///
+    /// The provided str slice should be uppercase!
     pub fn from_str(region_short: &str) -> Option<Region> {
         match region_short {
-            "eu" | "ею" => Some(Region::EuropeanUnion),
-            "eea" => Some(Region::EuropeanEconomicArea),
-            "benelux" => Some(Region::Benelux),
-            "5e" => Some(Region::FiveEyes),
-            "6e" => Some(Region::SixEyes),
-            "9e" => Some(Region::NineEyes),
-            "14e" => Some(Region::FourteenEyes),
+            "EU" | "ЕЮ" => Some(Region::EuropeanUnion),
+            "EEA" => Some(Region::EuropeanEconomicArea),
+            "BENELUX" => Some(Region::Benelux),
+            "5E" => Some(Region::FiveEyes),
+            "6E" => Some(Region::SixEyes),
+            "9E" => Some(Region::NineEyes),
+            "14E" => Some(Region::FourteenEyes),
             _ => None,
         }
     }
 
     pub fn short(&self) -> &'static str {
         match self {
-            Region::EuropeanUnion => "eu",
-            Region::EuropeanEconomicArea => "eea",
-            Region::Benelux => "benelux",
-            Region::FiveEyes => "5e",
-            Region::SixEyes => "6e",
-            Region::NineEyes => "9e",
-            Region::FourteenEyes => "14e",
+            Region::EuropeanUnion => "EU",
+            Region::EuropeanEconomicArea => "EEA",
+            Region::Benelux => "BENELUX",
+            Region::FiveEyes => "5E",
+            Region::SixEyes => "6E",
+            Region::NineEyes => "9E",
+            Region::FourteenEyes => "14E",
         }
     }
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -195,6 +195,19 @@ impl CountriesFilter {
     }
 }
 
+impl From<Region> for CountriesFilter {
+    fn from(region: Region) -> CountriesFilter {
+        CountriesFilter {
+            countries: HashSet::from_iter(
+                region
+                    .countries()
+                    .into_iter()
+                    .map(|str_slice| String::from(str_slice)),
+            ),
+        }
+    }
+}
+
 impl From<HashSet<String>> for CountriesFilter {
     fn from(countries: HashSet<String>) -> CountriesFilter {
         CountriesFilter { countries }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -61,7 +61,7 @@ impl<'a> From<&'a str> for CountryFilter {
 
 #[derive(Debug, PartialEq)]
 pub enum Region {
-    /// The European Union, consisting of 27 countries.
+    /// The [European Union](https://en.wikipedia.org/wiki/European_Union), consisting of 27 countries.
     ///
     /// Because of the Brexit, the United Kingdom is not included in this region
     EuropeanUnion,
@@ -83,7 +83,7 @@ impl Region {
     /// Tries to create a Region from a string slice. Returns a Region if there's one represented
     /// by your str slice. Returns None otherwise.
     ///
-    /// The provided str slice should be uppercase!
+    /// The provided str slice should be **uppercase**!
     pub fn from_str(region_short: &str) -> Option<Region> {
         match region_short {
             "EU" | "ЕЮ" => Some(Region::EuropeanUnion),
@@ -104,7 +104,7 @@ impl Region {
     pub fn from_str_options() -> [(&'static str, &'static str); 8] {
         [
             ("EU", "The European Union"),
-            ("ЕЮ", "The European Union"),
+            ("ЕЮ", "The European Union (Cyrillic notation)"),
             ("EEA", "The European Economic Area"),
             ("BENELUX", "Countries of the Benelux"),
             ("5E", "Countries involved in the Five Eyes programme."),

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -184,7 +184,7 @@ impl CountriesFilter {
     /// always return `Some(CountriesFilter)`.
     #[deprecated(
         since = "1.1.0",
-        note = "Use the Region object instead. It has more regions and better."
+        note = "Use the Region object instead. It has more regions and works better."
     )]
     #[allow(deprecated)]
     pub fn from_region(region: &str) -> Option<CountriesFilter> {
@@ -207,7 +207,7 @@ impl CountriesFilter {
     /// should always give a `Some`-value.
     #[deprecated(
         since = "1.1.0",
-        note = "Use the Region object instead. It has more regions and better."
+        note = "Use the Region object instead. It has more regions and works better."
     )]
     pub fn available_regions() -> &'static [&'static str] {
         &["EU", "ЕЮ"]
@@ -217,7 +217,7 @@ impl CountriesFilter {
     /// [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format.
     #[deprecated(
         since = "1.1.0",
-        note = "Use the Region object instead. It has more regions and better."
+        note = "Use the Region object instead. It has more regions and works better."
     )]
     pub fn region_countries(region: &str) -> Option<&'static [&'static str]> {
         match region.as_ref() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,13 +83,15 @@ fn show_available_filters(data: &Servers) {
         iter.for_each(|flag| print!(", {}", flag.to_lowercase()));
     }
     println!();
+    println!();
 
     // Show regions
-    print!("REGIONS:\t");
-    let mut iter = nordselect::filters::CountriesFilter::available_regions().into_iter();
+    println!("REGIONS:");
+    let iter = nordselect::filters::Region::from_str_options();
+    let mut iter = iter.into_iter();
     if let Some(flag) = iter.next() {
-        print!("{}", flag.to_lowercase());
-        iter.for_each(|flag| print!(", {}", flag.to_lowercase()));
+        println!("{}\t{}", flag.0.to_lowercase(), flag.1);
+        iter.for_each(|flag| println!("{}\t{}", flag.0.to_lowercase(), flag.1));
         println!();
     }
 }
@@ -122,17 +124,17 @@ fn parse_filters(cli_filters: clap::Values, data: &Servers) -> PossibleFilters {
                         .unwrap()
                         .insert(upper);
                 } else if let Some(region_countries) =
-                    nordselect::filters::CountriesFilter::region_countries(&upper.as_ref())
+                    nordselect::filters::Region::from_str(&filter.to_uppercase())
                 {
                     if parsed_filters.country_filter.is_none() {
                         parsed_filters.country_filter = Some(HashSet::new());
                     }
-                    region_countries.iter().for_each(|flag| {
+                    region_countries.countries().into_iter().for_each(|flag| {
                         parsed_filters
                             .country_filter
                             .as_mut()
                             .unwrap()
-                            .insert(String::from(*flag));
+                            .insert(String::from(flag));
                         ()
                     });
                 } else {


### PR DESCRIPTION
Now, regions are located in the CountriesFilter struct, a place where they do not belong. The solution was rather *ad hoc*.
This PR creates a new Region-enum, providing a more clean interface to use regions, that is more extensible as well.