### PR TITLE
Make country test succeed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.1.1 (unreleased)
+
+- Bugfix in the test of the simple country filter.
+
 ## Version 1.1.0
 
 - Rewrote the regions system, allowing a more clean interface to developers.

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -492,7 +492,7 @@ mod tests {
         let mut data = Servers::dummy_data();
 
         data.filter(&CountriesFilter::from(HashSet::from_iter(
-            vec!["AX", "AY", "AZ"].into_iter().map(|x| x.to_string()),
+            vec!["AE", "AL", "AR"].into_iter().map(|x| x.to_string()),
         )));
 
         let server_opt = data.perfect_server();

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -490,15 +490,16 @@ mod tests {
     #[test]
     fn countries_filter_simple() {
         let mut data = Servers::dummy_data();
+        let vec = vec!["AE", "AL", "AR"];
 
         data.filter(&CountriesFilter::from(HashSet::from_iter(
-            vec!["AE", "AL", "AR"].into_iter().map(|x| x.to_string()),
+            vec.iter().map(|x| x.to_string()),
         )));
 
         let server_opt = data.perfect_server();
 
         assert!(server_opt.is_some());
-        assert_eq!(server_opt.unwrap().flag, "AZ");
+        assert!(vec.contains(&server_opt.unwrap().flag.as_str()));
     }
 
     #[test]


### PR DESCRIPTION
Due to NordVPN, one of the tests failed in the cronjob (the simple country filter took the wrong country)

I've fixed this by changing the countries. This test should not be able to fail soon (except when they decide to move their servers out of these countries).