### PR TITLE
Added ability to filter by specific load range

### DIFF
--- a/src/cli_help/parse_cli_args.rs
+++ b/src/cli_help/parse_cli_args.rs
@@ -19,6 +19,18 @@ pub fn parse_cli_args<'a>() -> clap::ArgMatches<'a> {
                 .takes_value(false),
         )
         .arg(
+            Arg::with_name("load_filter")
+                .short("l")
+                .long("load_filter")
+                .value_delimiter("-")
+                .require_delimiter(true)
+                .min_values(2)
+                .max_values(2)
+                .validator(validate_load_range)
+                .help("Use a range to filter on server load percentage. Ex. 40-60.")
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("tries")
                 .short("t")
                 .long("tries")
@@ -61,4 +73,16 @@ pub fn parse_cli_args<'a>() -> clap::ArgMatches<'a> {
                     See --filters"),
         )
         .get_matches()
+}
+
+fn validate_load_range(v: String) -> Result<(), String> {
+    if let Ok(number) = v.parse::<u8>() {
+        if number <= 100 {
+            Ok(())
+        } else {
+            Err(String::from("Please provide a value between 0 and 100."))
+        }
+    } else {
+        Err(String::from("Please provide numeric values for load range."))
+    }
 }

--- a/src/filters/load.rs
+++ b/src/filters/load.rs
@@ -9,24 +9,29 @@ use super::prelude::*;
 /// use nordselect::filters::LoadFilter;
 /// let mut data = Servers::dummy_data();
 ///
-/// // Filter on 10% load or less.
-/// data.filter(&LoadFilter::from(10));
-///
-/// assert!(data.perfect_server().is_some());
+/// // Filter on 10-40% load.
+/// data.filter(&LoadFilter::from((10, 40)));
+/// 
+/// assert!(data.perfect_server().load > 10);
 /// ```
 pub struct LoadFilter {
-    /// The maximal allowed load.
-    load: u8,
+    /// minimum allowed load
+    min_load: u8,
+    /// maximum allowed load
+    max_load: u8,
 }
 
-impl From<u8> for LoadFilter {
-    fn from(load: u8) -> LoadFilter {
-        LoadFilter { load }
+impl From<(u8,u8)> for LoadFilter {
+    fn from(loads: (u8, u8)) -> LoadFilter {
+        LoadFilter { min_load: loads.0, max_load: loads.1 }
     }
 }
 
 impl Filter for LoadFilter {
+    /// A server's load has to be Greater than the min_load
+    /// and Less than the max_load provided.
     fn filter(&self, server: &Server) -> bool {
-        server.load.cmp(&self.load) != std::cmp::Ordering::Greater
+        server.load.cmp(&self.min_load) == std::cmp::Ordering::Greater &&
+        server.load.cmp(&self.max_load) == std::cmp::Ordering::Less
     }
 }

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -21,7 +21,7 @@ pub use self::blacklist::BlackListFilter;
 pub use self::country::CountryFilter;
 pub use self::load::LoadFilter;
 pub use self::protocol::ProtocolFilter;
-pub use self::region::{CountriesFilter, Region};
+pub use self::region::{RegionFilter, Region};
 
 // Will be deleted in 3.0.0
 //#[deprecated(since="2.0.0")]
@@ -175,7 +175,7 @@ mod tests {
         use std::collections::HashSet;
         let mut data = Servers::dummy_data();
 
-        data.filter(&CountriesFilter::from(HashSet::with_capacity(0)));
+        data.filter(&RegionFilter::from(HashSet::with_capacity(0)));
 
         let server_opt = data.perfect_server();
 
@@ -190,7 +190,7 @@ mod tests {
         let mut data = Servers::dummy_data();
         let vec = vec!["AE", "AL", "AR"];
 
-        data.filter(&CountriesFilter::from(HashSet::from_iter(
+        data.filter(&RegionFilter::from(HashSet::from_iter(
             vec.iter().map(|x| x.to_string()),
         )));
 

--- a/src/servers.rs
+++ b/src/servers.rs
@@ -120,8 +120,10 @@ pub struct Server {
     pub load: u8,
     /// Categories this server is in.
     pub categories: Vec<ServerCategory>,
-    /// Features of the server
+    /// Features of the server.
     pub features: Features,
+    /// Ping result in milliseconds.
+    pub ping_result: usize,
 }
 
 impl Hash for Server {
@@ -143,6 +145,7 @@ impl From<ApiServer> for Server {
                     .map(|server_type| ServerCategory::from(server_type.name)),
             ),
             features: api_server.features,
+            ping_result: 0,
         }
     }
 }


### PR DESCRIPTION
If you supply -l on the cli, you can provide a range (ex. 40-60) and it will only query servers that have a load within that range.


Originally did a bunch of stuff on master, then realized it was outdated :\ 
I had the ping stuff working on there, but it looks like it doesn't work quite yet on the 'next' branch. I left the `ping_result` variable in so I can tinker later.

Tests are a little messed up still - I saw that they weren't running successfully on `next` anyway.

Not sure if this is even wanted, but here it is!